### PR TITLE
Fix RHEL-07-010491 grub superusers config

### DIFF
--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -192,7 +192,7 @@
       "HIGH | RHEL-07-010482 | Red Hat Enterprise Linux operating systems version 7.2 or newer with a Basic Input/Output System (BIOS) must require authentication upon booting into single-user and maintenance modes."
       "HIGH | RHEL-07-010491 | Red Hat Enterprise Linux operating systems version 7.2 or newer using Unified Extensible Firmware Interface (UEFI) must require authentication upon booting into single-user and maintenance modes."
     lineinfile:
-      path: /boot/grub2/grub.cfg
+      path: /etc/grub.d/01_users
       regexp: "{{ item.regexp }}"
       line: "{{ item.line }}"
     notify: 


### PR DESCRIPTION
The RHEL-07-010491 task in fix-cat1.yml attempts to check/update `/boot/grub2/grub.cfg`, but this file does not exist on UEFI systems and the task fails. The old version of the role performed this task on `/etc/grub.d/01_users` which seems more proper since direct edits to grub.cfg are overwritten by `grub2-mkconfig`.

Signed-off-by: Dan Barr <dan@dbarr.com>