### PR TITLE
Fix variable name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -673,10 +673,10 @@ rhel7stig_int_gid: 1000
 # Sets the invalid rate limit for IPv4 connections. Should be set to less than 1000 to conform to STIG standards
 ol7stig_ipv4_tcp_invalid_ratelimit: 500
 
-# Control OL-07-021031
+# Control RHEL-07-021031
 # This control sets all world writable files to be owned by root. To conform to STIG standard all world-writable files must be owned by root or another system account
 # With this toggle off it will list all world-writable files not owned by system accounts
-ol7stig_world_write_files_owner_root: false
+rhel7stig_world_write_files_owner_root: false
 
 # how to get audit files onto host options
 # options are git/copy/get_url


### PR DESCRIPTION
RHEL-07-021031 task fails because the conditional `rhel7stig_world_write_files_owner_root` does not exist. In defaults/main.yml it's defined as `ol7stig_world_write_files_owner_root`; updating to fix the name and control # in the comment.

Sidebar: the preceding variable in the defaults, ol7stig_ipv4_tcp_invalid_ratelimit, isn't used anywhere in the role and probably could be removed, but I didn't do that in this PR.

Signed-off-by: Dan Barr <dan@dbarr.com>