### PR TITLE
Syslog format by default

### DIFF
--- a/templates/aide.conf.j2
+++ b/templates/aide.conf.j2
@@ -17,8 +17,11 @@ gzip_dbout=yes
 # Default.
 verbose=5
 
-report_url=file:@@{LOGDIR}/aide.log
-report_url=stdout
+# One line per timestamp for better external logger support
+syslog_format = true
+report_url=syslog:LOG_AUTH
+#report_url=file:@@{LOGDIR}/aide.log
+#report_url=stdout
 #report_url=stderr
 #NOT IMPLEMENTED report_url=mailto:root@foo.com
 #NOT IMPLEMENTED report_url=syslog:LOG_AUTH


### PR DESCRIPTION

**Overall Review of Changes:**
Use syslog format for one line per timestamp for better external logger support (i.e. Splunk)

**Issue Fixes:**
By default, aide logs are multi-line without timestamp making external logger parsing complex.

**Enhancements:**
Each log output line has a timestamp

**How has this been tested?:**
Tested locally with an instance using this repo, verified output logs are syslog format.

