### PR TITLE
Update main.yml to reflect correct clamav package names

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -388,9 +388,9 @@ rhel7stig_antivirus_required: false
 rhel7stig_av_package:
     package:
         - clamav
-        - clamav-scanner
-        - clamav-server
-    service: clamav-daemon
+        - clamav-update
+        - clamd
+    service: clamd
 
 rhel7stig_time_service: chronyd
 rhel7stig_time_service_configs:


### PR DESCRIPTION
corrected clamav package names to reflect current packages for RHEL/CentOS

**Overall Review of Changes:**
At some point clamav must have changed their package naming - the proposed changes match the current package names in EPEL

**Issue Fixes:**
none
**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
tested from fresh pull of repo and testing against fresh CentOS7 VM

