### PR TITLE
Add var for audit daemon process, fix failing test for rhel7stig_bootloader_password_hash, update readme

### DIFF
--- a/.github/workflows/main.tf
+++ b/.github/workflows/main.tf
@@ -78,6 +78,6 @@ resource "local_file" "inventory" {
         run_audit: true
         system_is_ec2: true
         audit_git_version: devel
-        rhel7stig_bootloader_password_hash: 'grub.pbkdf2.sha512.thishasbeenchangedfortesting'
+        rhel7stig_bootloader_password_hash: 'grub.pbkdf2.sha512.10000.222B96F1DE956C712CE287FA5257E6344EFED2CF83C4232F9F497FDC9B294CC9783F9F27CC4CD74582262FAE63BDFCCF50D6BA2542A6B774C50BCE9E28A3EB1F.DDF132BFF869485A5B4F9B2B53AE8E1A429E87F31BC863DB18DB5ED1AE4E5B8AED1EAE86F0073AFED3D9E01B7137A192D7D61F40EAE4806BBD172B0B1979DAE1'
     EOF
 }

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Access to download or add the goss binary and content to the system if using aud
 
 - Python3 (preferred)
 - Ansible 2.9+
+- jmespath
 
 Ansible is set to run in a python3 environment.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -636,6 +636,7 @@ rhel7stig_auditd_space_left: "{{ ( ansible_mounts | json_query(rhel7stig_audit_d
 rhel7stig_audit_disk_size_query: "[?mount=='{{ rhel7stig_audit_part }}'].size_total | [0]"
 
 # RHEL-07-030350
+rhel7stig_audit_daemon: auditd
 rhel7stig_auditd_mail_acct: root
 
 # RHEL-07-020630

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -27,7 +27,7 @@
 - name: make grub2 config
   command: /usr/sbin/grub2-mkconfig --output={{ rhel7stig_grub_cfg_path }}
   when:
-      - rhel7stig_grub2_user_cfg.stat.exists
+      - (rhel7stig_grub2_user_cfg.stat.exists) and (rhel7stig_grub2_user_cfg.stat.exists is defined)
       - not rhel7stig_skip_for_travis
       - not rhel7stig_system_is_container
 
@@ -63,7 +63,7 @@
       owner: root
       group: root
       mode: 0600
-  notify: restart "{{ rhel7stig_audit_daemon }}"
+  notify: restart auditd
 
 - name: restart auditd
   command: /usr/sbin/service "{{ rhel7stig_audit_daemon }}" restart

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -63,10 +63,10 @@
       owner: root
       group: root
       mode: 0600
-  notify: restart auditd
+  notify: restart "{{ rhel7stig_audit_daemon }}"
 
 - name: restart auditd
-  command: /usr/sbin/service auditd restart
+  command: /usr/sbin/service "{{ rhel7stig_audit_daemon }}" restart
   args:
       warn: no
   when:

--- a/site.yml
+++ b/site.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: ansible-lockdown
   become: true
   vars:
       is_container: false

--- a/site.yml
+++ b/site.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: ansible-lockdown
+- hosts: all
   become: true
   vars:
       is_container: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
 - name: Check rhel7stig_bootloader_password_hash variable has been changed
   assert:
       that: rhel7stig_bootloader_password_hash != 'grub.pbkdf2.sha512.changethispassword'
-      msg: "This role will not be able to run single user password commands as rhel7stig_bootloader_password_hash variable has not been set"
+      msg: "This role will not be able to run single user password commands as rhel7stig_bootloader_password_hash variable has not been set. You can set the hash or a RHEL 7.9 system using the command 'grub2-mkpasswd-pbkdf2'"
   when:
       - rhel_07_010481 or
         rhel_07_010482 or

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
 - name: Check rhel7stig_bootloader_password_hash variable has been changed
   assert:
       that: rhel7stig_bootloader_password_hash != 'grub.pbkdf2.sha512.changethispassword'
-      msg: "This role will not be able to run single user password commands as rhel7stig_bootloader_password_hash variable has not been set. You can set the hash or a RHEL 7.9 system using the command 'grub2-mkpasswd-pbkdf2'"
+      msg: "This role will not be able to run single user password commands as rhel7stig_bootloader_password_hash variable has not been set. You can create the hash on a RHEL 7.9 system using the command 'grub2-mkpasswd-pbkdf2'"
   when:
       - rhel_07_010481 or
         rhel_07_010482 or


### PR DESCRIPTION
**Overall Review of Changes:**
1.) Make audit daemon process reference  a var. auditd might not be used and the handler will fail if audit is not used. 
2.) Fix **make grub2 config** to require that the variable is defined.
3.) Update README.md to include jmespath
4.) Include extra description for creating rhel7stig_bootloader_password_hash
5.) Add a hash for "abc123" password for rhel7stig_bootloader_password_hash in main.tf

**Issue Fixes:**
resolves #412 

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
Please give an overview of how these changes were tested. If they were not please use N/A

