### PR TITLE
Remove use of deprecated shell module warnings feature in Ansible

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -58,8 +58,6 @@
 
 - name: restart auditd
   ansible.builtin.shell: /usr/sbin/service "{{ rhel7stig_audit_daemon }}" restart
-  args:
-      warn: false
 
 - name: rebuild initramfs
   ansible.builtin.shell: dracut -f

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -4,8 +4,6 @@
       - name: "HIGH | RHEL-07-010010 | AUDIT | The Red Hat Enterprise Linux operating system must be configured so that the file permissions, ownership, and group membership of system files and commands match the vendor values."
         ansible.builtin.shell: |
             rpm -Va --nolinkto --nofiledigest --nosize --nomtime --nodigest --nosignature | grep -E '^(.M|.....U|......G)' | tee /dev/stderr | cut -c13- | sed 's/^ //' | xargs rpm -qf --qf='%{name}\n' | sort -u
-        args:
-            warn: false
         check_mode: false
         failed_when: false
         changed_when: false

--- a/tasks/post_remediation_audit.yml
+++ b/tasks/post_remediation_audit.yml
@@ -5,8 +5,6 @@
   environment: "{{ audit_run_script_environment | default({}) }}"
   changed_when: false
   register: audit_run_post_remediation
-  vars:
-      warn: false
 
 - name: Post Audit | ensure audit files readable by users
   ansible.builtin.file:

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -18,8 +18,6 @@
         failed_when: ( python36_rpm_present.rc not in [ 0, 1 ] )
         changed_when: false
         register: python36_rpm_present
-        args:
-            warn: false
 
       - name: "PRELIM | Add the EPEL repository required for the python36-rpm pkg"
         ansible.builtin.package:


### PR DESCRIPTION
**Overall Review of Changes:**
Currently, this role can break when used with Ansible 2.14 and later because of the use of the warn argument to suppress warning output has been removed. Ansible no longer displays these warnings as of version 2.11. These change simply remove the use of this argument when using the shell module in order to restore compatibility with newer versions of Ansible.

See this PR for more information on the deprecated warnings feature in Ansible: https://github.com/ansible/ansible/pull/70504

**How has this been tested?:**
N/A

