### PR TITLE
Improve sudo user password check

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.1 Stig V3r11 27th April 2023
+
+- #428 improvement in test for sudo user has a passwd set
+
 ## 2.1 Stig V3r11 27th April 2023
 
 Consistent on ansible version

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,8 +37,10 @@
             success_msg: "You a password set for the {{ ansible_env.SUDO_USER }}"
         vars:
             sudo_password_rule: RHEL-07-010340
+            
   when:
       - rhel_07_010340
+      - ansible_env.SUDO_USER is defined
   tags:
       - user_passwd
 


### PR DESCRIPTION
Overall Review of Changes:
Improve password check for rule RHEL-07-010340 that sudo user must have a password or sudo will fail to work.

Issue Fixes:
https://github.com/ansible-lockdown/RHEL7-STIG/issues/428

Enhancements:
Only run if the playbook is not being run as a super user

How has this been tested?:
Manually

