### PR TITLE
Update fix-cat2.yml

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1350,7 +1350,7 @@
             enabled: false
             state: stopped
         when:
-            - rhel_07_020110_autofs_service_status == "loaded"
+            - rhel_07_020110_autofs_service_status.stdout == "loaded"
             - not rhel7stig_autofs_required
   when:
       - rhel_07_020110

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -152,7 +152,7 @@
             path: /etc/dconf/db/local.d/00-login-screen
             line: "{{ item }}"
             mode: '0644'
-            create": true
+            create: true
         loop:
             - [org/gnome/login-screen]
             - disable-user-list=true
@@ -163,7 +163,7 @@
             path: /etc/dconf/profile/gdm
             line: "{{ item }}"
             mode: '0644'
-            create": true
+            create: true
         loop:
             - user-db:user
             - system-db:gdm


### PR DESCRIPTION
Removes quote  `"` character from module parameter.  This causes a task failure and ansible reports that it's an unknown module parameter.

**Overall Review of Changes:**
Modifies lines 155, and 166 and removes extraneous quote character

**Issue Fixes:**
I have not opened an issue for this but can do so if needed.
Resolves an issue in fix-cat2.yml with the task for RHEL-07-010063
Ansible reports that create\" is an unsupported module parameter for lineinfile module.

**Enhancements:**
None

**How has this been tested?:**
Made the modifications describe above, and ran the stig role against a RHEL 7.9 system and failed task RHEL-07-010063 now works as expected.

