### PR TITLE
Excluding non-interactive login shells from being parsed from /etc/pa…

### DIFF
--- a/tasks/parse_etc_passwd.yml
+++ b/tasks/parse_etc_passwd.yml
@@ -2,7 +2,7 @@
 - name: "PRELIM | {{ rhel7stig_passwd_tasks }} | Parse /etc/passwd"
   block:
       - name: "PRELIM | {{ rhel7stig_passwd_tasks }} | Parse /etc/passwd"
-        ansible.builtin.shell: cat /etc/passwd
+        ansible.builtin.shell: cat /etc/passwd | grep -v '/sbin/nologin\|/usr/sbin/nologin'
         changed_when: false
         check_mode: false
         register: rhel7stig_passwd_file_audit


### PR DESCRIPTION
…sswd

**Overall Review of Changes:**
Excludes non interactive shells listed in /etc/shells from being registered in the rhel7stig_passwd_file_audit variable

**Issue Fixes:**
https://github.com/ansible-lockdown/RHEL7-STIG/issues/462

**Enhancements:**
N/A

**How has this been tested?:**
tested code in separate task, results were as expected
